### PR TITLE
Create a script to auto install spool and dependencies

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -1,10 +1,10 @@
-var createError = require('http-errors');
-var express = require('express');
-var path = require('path');
-var logger = require('morgan');
-var dotenv = require('dotenv');
+const createError = require('http-errors');
+const express = require('express');
+const path = require('path');
+const logger = require('morgan');
+const dotenv = require('dotenv');
 
-var {Validator, ValidationError} = require('express-json-validator-middleware');
+let {Validator, ValidationError} = require('express-json-validator-middleware');
 
 const frontEndRouter = require('./routes/access/access');
 const documentationRouter = require('./swagger-jsdoc');
@@ -12,7 +12,7 @@ const documentationRouter = require('./swagger-jsdoc');
 // Load environment variables from .env
 dotenv.config();
 
-var app = express();
+let app = express();
 
 app.use(logger('dev'));
 app.use(express.json());

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     env_file:
       - envdev
     ports:
-      - "3002:3002"
+      - "443:3002"
     restart: always
     volumes:
       - ./:/usr/src/app

--- a/setup/Generate-Certificates.sh
+++ b/setup/Generate-Certificates.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+#  GenerateCertificates.sh
+#  
+#
+#  Created by Eli Winkelman on 7/29/20.
+#
+
+create_development_server_ca(){
+
+    # create an ec key
+    openssl ecparam -name prime256v1 -genkey -noout -out ca.key
+    
+    # create a CA
+    openssl req -config /Users/eliwinkelman/OPEnS/MongoServer/secrets/config.txt -new -key ca.key -x509 -days 10000 -out ca.crt
+
+}
+
+create_development_server_certificate()
+{
+    # generate a new key
+    openssl genrsa -out server-key.pem 2048
+    echo Created Key
+    
+    # generate a new CSR which uses this key and output to server.csr
+    openssl req -new -sha256 -key server-key.pem -out CSR.csr -subj "/C=US/ST=Oregon/L=Corvallis/O=OPEnS Lab/OU=R&D/CN=localhost"
+    echo Created CSR
+    # generate a new certificate with the csr that is signed by the certificate authority
+    openssl x509 -req -in CSR.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server-crt.pem -days 365
+}
+
+# create secrets directory
+mkdir secrets
+cd secrets
+create_development_server_ca
+create_development_server_certificate

--- a/setup/Install-Spool.sh
+++ b/setup/Install-Spool.sh
@@ -12,11 +12,12 @@ cd Spool_Application
 git clone https://github.com/OPEnSLab-OSU/Spool.git
 
 cd Spool
-#npm install
+
+npm install
 
 cd ..
 
 echo $PWD
 
-/bin/bash $PWD/Spool/setup/Generate-Certificates.sh
+/bin/bash Spool/setup/Generate-Certificates.sh
 

--- a/setup/Install-Spool.sh
+++ b/setup/Install-Spool.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#  Install-Spool.sh
+#  
+#
+#  Created by Eli Winkelman on 7/30/20.
+#  
+
+mkdir Spool_Application
+cd Spool_Application
+
+git clone https://github.com/OPEnSLab-OSU/Spool.git
+
+cd Spool
+#npm install
+
+cd ..
+
+echo $PWD
+
+/bin/bash $PWD/Spool/setup/Generate-Certificates.sh
+


### PR DESCRIPTION
Install-Spool.sh provides an auto-install script for users to curl
Generate-Certificates.sh generates development certificate authority and tls certificates for the server. NOT for generating production certificates.

Install script requires a user to have npm installed already.